### PR TITLE
[ME-3679] add ie support

### DIFF
--- a/Source/ManagedNativeWifi/BssEntryWrapper.cs
+++ b/Source/ManagedNativeWifi/BssEntryWrapper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static ManagedNativeWifi.Win32.NativeMethod;
+
+namespace ManagedNativeWifi
+{
+	/// <summary>
+	/// Wrapper for native WLAN_BSS_ENTRY struct
+	/// </summary>
+	internal class BssEntryWrapper
+	{
+		/// <summary>
+		/// BSS entry
+		/// </summary>
+		internal WLAN_BSS_ENTRY BssEntry { get; }
+
+		/// <summary>
+		/// IEs
+		/// </summary>
+		internal byte[] IEs { get; }
+
+		internal BssEntryWrapper(
+			WLAN_BSS_ENTRY bssEntry,
+			byte[] ies)
+		{
+			this.BssEntry = bssEntry;
+			this.IEs = ies;
+		}
+	}
+}

--- a/Source/ManagedNativeWifi/BssEntryWrapperList.cs
+++ b/Source/ManagedNativeWifi/BssEntryWrapperList.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using static ManagedNativeWifi.Win32.NativeMethod;
+
+namespace ManagedNativeWifi
+{
+	/// <summary>
+	/// Corresponds to native WLAN_BSS_LIST struct
+	/// </summary>
+	internal class BssEntryWrapperList
+	{
+		/// <summary>
+		/// Total size (bytes)
+		/// </summary>
+		internal uint DwTotalSize { get; }
+
+		/// <summary>
+		/// Number of items
+		/// </summary>
+		internal uint DwNumberOfItems { get; }
+
+		/// <summary>
+		/// BSS entry wrappers
+		/// </summary>
+		internal BssEntryWrapper[] BssEntryWrappers { get; }
+
+		internal BssEntryWrapperList(IntPtr ppWlanBssList)
+		{
+			var uintSize = Marshal.SizeOf<uint>(); // 4
+
+			WLAN_BSS_LIST bssList = new WLAN_BSS_LIST(ppWlanBssList);
+			this.DwTotalSize = bssList.dwTotalSize;
+			this.DwNumberOfItems = bssList.dwNumberOfItems;
+			this.BssEntryWrappers = new BssEntryWrapper[bssList.dwNumberOfItems];
+
+			for (int i = 0; i < bssList.dwNumberOfItems; i++)
+			{
+				var bssEntry = bssList.wlanBssEntries[i];
+				var ppIe = new IntPtr(ppWlanBssList.ToInt64()
+					+ (uintSize * 2) /* Offset for dwTotalSize and dwNumberOfItems */
+					+ (Marshal.SizeOf<WLAN_BSS_ENTRY>() * i) /* Offset for preceding items */
+					+ bssEntry.ulIeOffset /* Offset for IEs */);
+
+				this.BssEntryWrappers[i] = new BssEntryWrapper(
+					bssEntry: bssEntry,
+					ies: new byte[bssEntry.ulIeSize]);
+				Marshal.Copy(ppIe, this.BssEntryWrappers[i].IEs, 0, (int)bssEntry.ulIeSize);
+			}
+		}
+	}
+}

--- a/Source/ManagedNativeWifi/BssNetworkPack.cs
+++ b/Source/ManagedNativeWifi/BssNetworkPack.cs
@@ -62,6 +62,11 @@ namespace ManagedNativeWifi
 		public int Channel { get; }
 
 		/// <summary>
+		/// IEs
+		/// </summary>
+		public byte[] IEs { get; }
+
+		/// <summary>
 		/// Constructor
 		/// </summary>
 		public BssNetworkPack(
@@ -74,7 +79,8 @@ namespace ManagedNativeWifi
 			int linkQuality,
 			int frequency,
 			float band,
-			int channel)
+			int channel,
+			byte[] ies)
 		{
 			this.Interface = interfaceInfo;
 			this.Ssid = ssid;
@@ -86,6 +92,7 @@ namespace ManagedNativeWifi
 			this.Frequency = frequency;
 			this.Band = band;
 			this.Channel = channel;
+			this.IEs = ies;
 		}
 	}
 }

--- a/Source/ManagedNativeWifi/NativeWifi.cs
+++ b/Source/ManagedNativeWifi/NativeWifi.cs
@@ -375,15 +375,25 @@ namespace ManagedNativeWifi
 
 			foreach (var interfaceInfo in EnumerateInterfaces(container.Content))
 			{
-				foreach (var networkBssEntry in Base.GetNetworkBssEntryList(container.Content.Handle, interfaceInfo.Id))
+				foreach (var networkBssEntryWrapper in Base.GetNetworkBssEntryWrapperList(container.Content.Handle, interfaceInfo.Id))
 				{
-					if (TryConvertBssNetwork(interfaceInfo, networkBssEntry, out BssNetworkPack bssNetwork))
+					if (TryConvertBssNetwork(interfaceInfo, networkBssEntryWrapper, out BssNetworkPack bssNetwork))
 						yield return bssNetwork;
 				}
 			}
 		}
 
+		private static bool TryConvertBssNetwork(InterfaceInfo interfaceInfo, BssEntryWrapper bssEntryWrapper, out BssNetworkPack bssNetwork)
+		{
+			return TryConvertBssNetwork(interfaceInfo, bssEntryWrapper.BssEntry, bssEntryWrapper.IEs, out bssNetwork);
+		}
+
 		private static bool TryConvertBssNetwork(InterfaceInfo interfaceInfo, WLAN_BSS_ENTRY bssEntry, out BssNetworkPack bssNetwork)
+		{
+			return TryConvertBssNetwork(interfaceInfo, bssEntry, null, out bssNetwork);
+		}
+
+		private static bool TryConvertBssNetwork(InterfaceInfo interfaceInfo, WLAN_BSS_ENTRY bssEntry, byte[] ies, out BssNetworkPack bssNetwork)
 		{
 			bssNetwork = null;
 
@@ -403,7 +413,8 @@ namespace ManagedNativeWifi
 				linkQuality: (int)bssEntry.uLinkQuality,
 				frequency: (int)bssEntry.ulChCenterFrequency,
 				band: band,
-				channel: channel);
+				channel: channel,
+				ies: ies);
 			return true;
 		}
 

--- a/Source/ManagedNativeWifi/Win32/BaseMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/BaseMethod.cs
@@ -210,6 +210,38 @@ namespace ManagedNativeWifi.Win32
 			}
 		}
 
+		public static IEnumerable<BssEntryWrapper> GetNetworkBssEntryWrapperList(SafeClientHandle clientHandle, Guid interfaceId)
+		{
+			var wlanBssList = IntPtr.Zero;
+			try
+			{
+				var result = WlanGetNetworkBssList(
+					clientHandle,
+					interfaceId,
+					IntPtr.Zero,
+					DOT11_BSS_TYPE.dot11_BSS_type_any,
+					false,
+					IntPtr.Zero,
+					out wlanBssList);
+
+				// ERROR_INVALID_HANDLE: The client handle was not found in the handle table.
+				// ERROR_INVALID_PARAMETER: A parameter is incorrect. The interface is removed.
+				// ERROR_NOT_ENOUGH_MEMORY: Not enough memory is available to process this request.
+				// ERROR_NDIS_DOT11_POWER_STATE_INVALID: The interface is turned off.
+				// ERROR_NOT_FOUND: The inteface GUID could not be found.
+				// ERROR_NOT_SUPPORTED: The WLAN AutoConfig service is disabled.
+				// ERROR_SERVICE_NOT_ACTIVE: The WLAN AutoConfig service has not been started.
+				return CheckResult(nameof(WlanGetNetworkBssList), result, false)
+					? new BssEntryWrapperList(wlanBssList).BssEntryWrappers
+					: new BssEntryWrapper[0];
+			}
+			finally
+			{
+				if (wlanBssList != IntPtr.Zero)
+					WlanFreeMemory(wlanBssList);
+			}
+		}
+
 		public static IEnumerable<WLAN_BSS_ENTRY> GetNetworkBssEntryList(SafeClientHandle clientHandle, Guid interfaceId)
 		{
 			var wlanBssList = IntPtr.Zero;


### PR DESCRIPTION
Adds support for returning IEs when enumerating BSS networks.

A new wrapper class is created that corresponds to the WLAN_BSS_ENTRY type and contains the associated IEs. This allows for similarity and reuse of the existing design while maintaining type relationships.

The scope is limited to the EnumerateBssNetworks method but could be extended when needed.