### PR TITLE
[ME-4239] realtime connection quality

### DIFF
--- a/Source/ManagedNativeWifi/NativeWifi.cs
+++ b/Source/ManagedNativeWifi/NativeWifi.cs
@@ -998,6 +998,31 @@ namespace ManagedNativeWifi
 
 		#endregion
 
+		#region Realtime Connection Quality
+
+		/// <summary>
+		/// Gets realtime connection quality information of a specified wireless interface.
+		/// </summary>
+		/// <param name="interfaceId">Interface ID</param>
+		/// <returns>Realtime connection quality information.</returns>
+		public static RealtimeConnectionQuality GetInterfaceRealtimeConnectionQuality(Guid interfaceId)
+		{
+			return GetInterfaceRealtimeConnectionQuality(null, interfaceId);
+		}
+
+		internal static RealtimeConnectionQuality GetInterfaceRealtimeConnectionQuality(Base.WlanClient client, Guid interfaceId)
+		{
+			if (interfaceId == Guid.Empty)
+				throw new ArgumentException("The specified interface ID is invalid.", nameof(interfaceId));
+
+			using var container = new DisposableContainer<Base.WlanClient>(client);
+
+			var quality = Base.GetRealtimeConnectionQuality(container.Content.Handle, interfaceId);
+			return new RealtimeConnectionQuality(quality);
+		}
+
+		#endregion
+
 		#region Auto config
 
 		/// <summary>

--- a/Source/ManagedNativeWifi/RealtimeConnectionQuality.cs
+++ b/Source/ManagedNativeWifi/RealtimeConnectionQuality.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using static ManagedNativeWifi.Win32.NativeMethod;
+
+namespace ManagedNativeWifi
+{
+	/// <summary>
+	/// Realtime connection quality information
+	/// </summary>
+	public class RealtimeConnectionQuality
+	{
+		/// <summary>
+		/// PHY type
+		/// </summary>
+		public PhyType PhyType { get; }
+
+		/// <summary>
+		/// Link quality (0-100)
+		/// </summary>
+		public uint LinkQuality { get; }
+
+		/// <summary>
+		/// Receive rate (kbps)
+		/// </summary>
+		public uint RxRate { get; }
+
+		/// <summary>
+		/// Transmit rate (kbps)
+		/// </summary>
+		public uint TxRate { get; }
+
+		/// <summary>
+		/// Multi-Link connection
+		/// </summary>
+		public bool MultiLinkConnection { get; }
+
+		/// <summary>
+		/// Links
+		/// </summary>
+		public IReadOnlyList<RealtimeConnectionQualityLink> Links { get; }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RealtimeConnectionQuality(PhyType phyType, uint linkQuality, uint rxRate, uint txRate, bool multiLinkConnection, IEnumerable<RealtimeConnectionQualityLink> links)
+		{
+			this.PhyType = phyType;
+			this.LinkQuality = linkQuality;
+			this.RxRate = rxRate;
+			this.TxRate = txRate;
+			this.MultiLinkConnection = multiLinkConnection;
+			this.Links = Array.AsReadOnly(links?.ToArray() ?? Array.Empty<RealtimeConnectionQualityLink>());
+		}
+
+		internal RealtimeConnectionQuality(WLAN_REALTIME_CONNECTION_QUALITY quality)
+		{
+			PhyType = PhyTypeConverter.Convert(quality.dot11PhyType);
+			LinkQuality = quality.ulLinkQuality;
+			RxRate = quality.ulRxRate;
+			TxRate = quality.ulTxRate;
+			MultiLinkConnection = quality.bIsMLOConnection;
+			Links = quality.LinksInfo?.Select(x => new RealtimeConnectionQualityLink(x)).ToArray() ?? Array.Empty<RealtimeConnectionQualityLink>();
+		}
+	}
+}

--- a/Source/ManagedNativeWifi/RealtimeConnectionQualityLink.cs
+++ b/Source/ManagedNativeWifi/RealtimeConnectionQualityLink.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using static ManagedNativeWifi.Win32.NativeMethod;
+
+namespace ManagedNativeWifi
+{
+	/// <summary>
+	/// Realtime connection quality link information
+	/// </summary>
+	public class RealtimeConnectionQualityLink
+	{
+		/// <summary>
+		/// Link ID
+		/// </summary>
+		public byte LinkId { get; }
+
+		/// <summary>
+		/// Frequency (MHz)
+		/// </summary>
+		public uint Frequency { get; }
+
+		/// <summary>
+		/// Bandwidth (MHz)
+		/// </summary>
+		public uint Bandwidth { get; }
+
+		/// <summary>
+		/// Rssi (dBm)
+		/// </summary>
+		public int Rssi { get; }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RealtimeConnectionQualityLink(byte linkId, uint frequency, uint bandwidth, int rssi)
+		{
+			this.LinkId = linkId;
+			this.Frequency = frequency;
+			this.Bandwidth = bandwidth;
+			this.Rssi = rssi;
+		}
+
+		internal RealtimeConnectionQualityLink(WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO info)
+		{
+			LinkId = info.ucLinkID;
+			Frequency = info.ulChannelCenterFrequencyMhz;
+			Bandwidth = info.ulBandwidth;
+			Rssi = info.lRssi;
+		}
+	}
+}

--- a/Source/ManagedNativeWifi/Win32/BaseMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/BaseMethod.cs
@@ -623,6 +623,31 @@ namespace ManagedNativeWifi.Win32
 			}
 		}
 
+		public static WLAN_REALTIME_CONNECTION_QUALITY GetRealtimeConnectionQuality(SafeClientHandle clientHandle, Guid interfaceId)
+		{
+			var queryData = IntPtr.Zero;
+			try
+			{
+				var result = WlanQueryInterface(
+					clientHandle,
+					interfaceId,
+					WLAN_INTF_OPCODE.wlan_intf_opcode_realtime_connection_quality,
+					IntPtr.Zero,
+					out _,
+					out queryData,
+					IntPtr.Zero);
+
+				return CheckResult(nameof(WlanQueryInterface), result, false)
+					? new WLAN_REALTIME_CONNECTION_QUALITY(queryData)
+					: default;
+			}
+			finally
+			{
+				if (queryData != IntPtr.Zero)
+					WlanFreeMemory(queryData);
+			}
+		}
+
 		public static bool? IsAutoConfig(SafeClientHandle clientHandle, Guid interfaceId)
 		{
 			var value = GetInterfaceInt(clientHandle, interfaceId, WLAN_INTF_OPCODE.wlan_intf_opcode_autoconf_enabled);

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -424,6 +424,39 @@ namespace ManagedNativeWifi.Win32
 			}
 		}
 
+		public struct WLAN_REALTIME_CONNECTION_QUALITY
+		{
+			public DOT11_PHY_TYPE dot11PhyType;
+			public uint ulLinkQuality;
+			public uint ulRxRate;
+			public uint ulTxRate;
+			public bool bIsMLOConnection;
+			public uint ulNumLinks;
+			public WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO[] LinksInfo;
+
+			public WLAN_REALTIME_CONNECTION_QUALITY(IntPtr ppConnectionQuality)
+			{
+				var uintSize = Marshal.SizeOf<uint>(); // 4
+
+				dot11PhyType = (DOT11_PHY_TYPE)Marshal.ReadInt32(ppConnectionQuality);
+				ulLinkQuality = (uint)Marshal.ReadInt32(ppConnectionQuality, uintSize);
+				ulRxRate = (uint)Marshal.ReadInt32(ppConnectionQuality, uintSize * 2);
+				ulTxRate = (uint)Marshal.ReadInt32(ppConnectionQuality, uintSize * 3);
+				bIsMLOConnection = Marshal.ReadInt32(ppConnectionQuality, uintSize * 4) != 0;
+				ulNumLinks = (uint)Marshal.ReadInt32(ppConnectionQuality, uintSize * 5);
+				LinksInfo = new WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO[ulNumLinks];
+
+				for (int i = 0; i < ulNumLinks; i++)
+				{
+					var profileInfo = new IntPtr(ppConnectionQuality.ToInt64()
+						+ (uintSize * 6) /* Offset for non-array fields */
+						+ (Marshal.SizeOf<WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO>() * i) /* Offset for preceding items */);
+
+					LinksInfo[i] = Marshal.PtrToStructure<WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO>(profileInfo);
+				}
+			}
+		}
+
 		#endregion
 
 		#region Struct (Secondary)
@@ -587,6 +620,16 @@ namespace ManagedNativeWifi.Win32
 			public string strProfileXml;
 		}
 
+		[StructLayout(LayoutKind.Sequential)]
+		public struct WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO
+		{
+			public byte ucLinkID;
+			public uint ulChannelCenterFrequencyMhz;
+			public uint ulBandwidth;
+			public int lRssi;
+			public WLAN_RATE_SET wlanRateSet;
+		}
+
 		#endregion
 
 		#region Enum
@@ -719,6 +762,10 @@ namespace ManagedNativeWifi.Win32
 			wlan_intf_opcode_certified_safe_mode,
 			wlan_intf_opcode_hosted_network_capable,
 			wlan_intf_opcode_management_frame_protection_capable,
+			wlan_intf_opcode_secondary_sta_interfaces,
+			wlan_intf_opcode_secondary_sta_synchronized_connections,
+			wlan_intf_opcode_realtime_connection_quality,
+			wlan_intf_opcode_qos_info,
 			wlan_intf_opcode_autoconf_end = 0x0fffffff,
 			wlan_intf_opcode_msm_start = 0x10000100,
 			wlan_intf_opcode_statistics,

--- a/Source/ManagedNativeWifi/Win32/NativeMethod.cs
+++ b/Source/ManagedNativeWifi/Win32/NativeMethod.cs
@@ -448,11 +448,11 @@ namespace ManagedNativeWifi.Win32
 
 				for (int i = 0; i < ulNumLinks; i++)
 				{
-					var profileInfo = new IntPtr(ppConnectionQuality.ToInt64()
+					var linkInfo = new IntPtr(ppConnectionQuality.ToInt64()
 						+ (uintSize * 6) /* Offset for non-array fields */
 						+ (Marshal.SizeOf<WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO>() * i) /* Offset for preceding items */);
 
-					LinksInfo[i] = Marshal.PtrToStructure<WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO>(profileInfo);
+					LinksInfo[i] = Marshal.PtrToStructure<WLAN_REALTIME_CONNECTION_QUALITY_LINK_INFO>(linkInfo);
 				}
 			}
 		}


### PR DESCRIPTION
Adds support for the [WLAN_REALTIME_CONNECTION_QUALITY](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_realtime_connection_quality) structure and the `wlan_intf_opcode_realtime_connection_quality` that returns it.